### PR TITLE
Change to _RecentDrinkingLess

### DIFF
--- a/NIAAAPainStudy/assets/_RecentDrinkingFollowUp.xml
+++ b/NIAAAPainStudy/assets/_RecentDrinkingFollowUp.xml
@@ -5,7 +5,7 @@
         <question id = "11" type = "number">
             <text>HOW MANY DRINKS did you consume SINCE the last survey you answered? Please remember to answer in STANDARD drinks.</text>
             <answer id = "item">drink(s)</answer>
-            <answer id = "min">1</answer>
+            <answer id = "min">0</answer>
             <answer id = "max">24</answer>
         </question>
 <!-- 12 -->


### PR DESCRIPTION
Chen,

TLDR; I changed the title of the file _RecentDrinkingLess to _RecentDrinkingFollowUp to be more clear and, within it, I changed the response option from 1 - 24 to 0 - 24.

I realized there's a small issue with the question  "HOW MANY STANDARD DRINKS have you consumed SINCE THE LAST RECORDING?". From what I can tell, this same question is used in:

Initial Drink
Drink Followups
Any other prompt where participant answers Yes to Have you CONSUMED ALCOHOL since the last survey you answered?

as the first question. The spinner goes from 1 - 24, which works fine for Initial Drink and any prompt where participant answers Yes to "Have you CONSUMED ALCOHOL since the last survey you answered?" The participant has said that they've drank alcohol, so we don't need a 0.

However, it does not work for Drink Followups. The participant may not have had any drinks since the last survey, so we need a 0 option.

As best as I can tell, the _RecentDrinkingLess file contains the "HOW MANY STANDARD DRINKS have you consumed SINCE THE LAST RECORDING?" question version for the Drink Followups. I changed the title of the file to _RecentDrinkingFollowUp to be more clear and, within it, I changed the response option from 1 - 24 to 0 - 24.

I think this is a small change, but I wanted to be thorough about what I did. If I'm wrong and _RecentDrinkingLess was used for more than just the Followups, then we may need to do something else.

-Ryan
